### PR TITLE
Fix environment variables for production

### DIFF
--- a/src/utils/api-calls.ts
+++ b/src/utils/api-calls.ts
@@ -3,8 +3,9 @@
 // TODO: add more query params for "search" endpoints + pagination?
 // TODO: add types to all endpoints
 
-const BACKEND_HOST = process.env.BACKEND_URL || "http://localhost:8080";
-const BACKEND_API_VERSION = process.env.BACKEND_API_VERSION || "v1";
+const BACKEND_HOST =
+  process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8080";
+const BACKEND_API_VERSION = process.env.NEXT_PUBLIC_BACKEND_API_VERSION || "v1";
 const BACKEND_URL = `${BACKEND_HOST}/${BACKEND_API_VERSION}`;
 
 /*


### PR DESCRIPTION
Environment variable that must be available in the client's browser must be prefixed with "NEXT_PUBLIC" otherwise they will only be available on the frontend server